### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v2
     - uses: kciter/aws-ecr-action@v2
@@ -20,6 +22,8 @@ jobs:
   update-manifest:
     needs: build-and-push
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Potential fix for [https://github.com/bmatos312/platform-support-slackbot/security/code-scanning/4](https://github.com/bmatos312/platform-support-slackbot/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for each job. For the `build-and-push` job, no permissions are needed as it does not interact with the repository. For the `update-manifest` job, we will grant `contents: write` permission because it checks out a repository and commits changes. This ensures that the workflow operates securely with the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
